### PR TITLE
Generate processing server SSH keys automatically after add

### DIFF
--- a/grails-app/conf/ProcessingServerUrlMappings.groovy
+++ b/grails-app/conf/ProcessingServerUrlMappings.groovy
@@ -24,6 +24,10 @@ class ProcessingServerUrlMappings {
         "/api/processing_server/$id.$format"(controller: "restProcessingServer") {
             action = [GET: "show", PUT: "update", DELETE: "delete"]
         }
+
+        "/api/processing_server/$id/publickey"(controller: "restProcessingServer") {
+            action = [GET: "getPublicKey"]
+        }
     }
 
 }

--- a/grails-app/controllers/be/cytomine/api/RestController.groovy
+++ b/grails-app/controllers/be/cytomine/api/RestController.groovy
@@ -20,6 +20,7 @@ import be.cytomine.Exception.CytomineException
 import be.cytomine.test.HttpClient
 import be.cytomine.utils.Task
 import grails.converters.JSON
+import org.apache.commons.io.IOUtils
 import org.codehaus.groovy.grails.web.json.JSONArray
 
 import javax.imageio.ImageIO
@@ -275,6 +276,25 @@ class RestController {
         response.status = NOT_FOUND_CODE
         render(contentType: 'text/json') {
             errors(message: className + " not found with id " + filter1 + " : " + id1 + ",  " + filter2 + " : " + id2 + " and " + filter3 + " : " + id3)
+        }
+    }
+
+    protected  def responseText(String text)
+    {
+        response.getOutputStream() << text
+        response.getOutputStream().flush()
+    }
+    protected def downloadFile(String path, String name,String contentType) {
+        InputStream contentStream
+        try {
+            def file = new File(path)
+            response.setHeader "Content-disposition", "attachment; filename=$name"
+            response.setHeader("Content-Length", "file-size")
+            response.setContentType(contentType)
+            contentStream = file.newInputStream()
+            response.getOutputStream() << contentStream
+        } finally {
+            IOUtils.closeQuietly(contentStream)
         }
     }
 

--- a/grails-app/controllers/be/cytomine/api/processing/RestJobController.groovy
+++ b/grails-app/controllers/be/cytomine/api/processing/RestJobController.groovy
@@ -15,7 +15,6 @@ package be.cytomine.api.processing
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
 import be.cytomine.Exception.ConstraintException
 import be.cytomine.Exception.CytomineException
 import be.cytomine.Exception.CytomineMethodNotYetImplementedException

--- a/grails-app/controllers/be/cytomine/api/processing/RestProcessingServerController.groovy
+++ b/grails-app/controllers/be/cytomine/api/processing/RestProcessingServerController.groovy
@@ -59,7 +59,7 @@ class RestProcessingServerController extends RestController {
     def getPublicKey(){
         ProcessingServer processingServer = processingServerService.read(params.long('id'))
         if (processingServer) {
-            String nom= processingServer.host+".pub"
+            String name= processingServer.host+".pub"
             downloadFile(processingServerService.publicKeyProcessingServer(params.long('id')),nom,"text/plain")
         } else {
             responseNotFound("ProcessingServer", params.id)

--- a/grails-app/controllers/be/cytomine/api/processing/RestProcessingServerController.groovy
+++ b/grails-app/controllers/be/cytomine/api/processing/RestProcessingServerController.groovy
@@ -19,11 +19,15 @@ package be.cytomine.api.processing
 import be.cytomine.api.RestController
 import be.cytomine.processing.ProcessingServer
 import grails.converters.JSON
+import grails.util.Holders
 import org.restapidoc.annotation.RestApiMethod
 import org.restapidoc.annotation.RestApiObject
 import org.restapidoc.annotation.RestApiParam
 import org.restapidoc.annotation.RestApiParams
 import org.restapidoc.pojo.RestApiParamType
+
+import java.nio.file.Files
+import java.nio.file.Paths
 
 @RestApiObject(name = "Processing server services", description = "Methods for managing processing servers")
 class RestProcessingServerController extends RestController {
@@ -46,6 +50,20 @@ class RestProcessingServerController extends RestController {
         } else {
             responseNotFound("ProcessingServer", params.id)
         }
+    }
+
+    @RestApiMethod(description = "Get the public key of a specific processing server")
+    @RestApiParams(params = [
+            @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.PATH, description = "The processing server id")
+    ])
+    def getPublicKey(){
+        ProcessingServer processingServer = processingServerService.read(params.long('id'))
+        if (processingServer) {
+            responseText(processingServerService.publicKeyProcessingServer(params.long('id')))
+        } else {
+            responseNotFound("ProcessingServer", params.id)
+        }
+
     }
 
     @RestApiMethod(description = "Add a new processing server to Cytomine")

--- a/grails-app/controllers/be/cytomine/api/processing/RestProcessingServerController.groovy
+++ b/grails-app/controllers/be/cytomine/api/processing/RestProcessingServerController.groovy
@@ -59,7 +59,8 @@ class RestProcessingServerController extends RestController {
     def getPublicKey(){
         ProcessingServer processingServer = processingServerService.read(params.long('id'))
         if (processingServer) {
-            responseText(processingServerService.publicKeyProcessingServer(params.long('id')))
+            String nom= processingServer.host+".pub"
+            downloadFile(processingServerService.publicKeyProcessingServer(params.long('id')),nom,"text/plain")
         } else {
             responseNotFound("ProcessingServer", params.id)
         }

--- a/grails-app/domain/be/cytomine/processing/ProcessingServer.groovy
+++ b/grails-app/domain/be/cytomine/processing/ProcessingServer.groovy
@@ -98,15 +98,15 @@ class ProcessingServer extends CytomineDomain {
     static ProcessingServer insertDataIntoDomain(def json, def domain = new ProcessingServer()) {
         domain.id = JSONUtils.getJSONAttrLong(json, 'id', null)
         domain.name = JSONUtils.getJSONAttrStr(json, 'name', true)
-        domain.host = JSONUtils.getJSONAttrStr(json, 'host', true)
+        domain.host =JSONUtils.getJSONAttrStr(json, 'host', true)
         domain.username = JSONUtils.getJSONAttrStr(json, 'username', true)
         domain.port = JSONUtils.getJSONAttrInteger(json, 'port', null)
         domain.type = JSONUtils.getJSONAttrStr(json, 'type', true)
         domain.processingMethodName = JSONUtils.getJSONAttrStr(json, 'processingMethodName', true)
         domain.amqpQueue = JSONUtils.getJSONAttrDomain(json, 'amqpQueue', new AmqpQueue(), false)
-        domain.type = JSONUtils.getJSONAttrStr(json, 'persistentDirectory', false)
-        domain.type = JSONUtils.getJSONAttrStr(json, 'workingDirectory', false)
-        domain.type = JSONUtils.getJSONAttrInteger(json, 'index', 10)
+        domain.persistentDirectory = JSONUtils.getJSONAttrStr(json, 'persistentDirectory', false)
+        domain.workingDirectory = JSONUtils.getJSONAttrStr(json, 'workingDirectory', false)
+        domain.index = JSONUtils.getJSONAttrInteger(json, 'index', 10)
         return domain
     }
 

--- a/grails-app/services/be/cytomine/processing/ProcessingServerService.groovy
+++ b/grails-app/services/be/cytomine/processing/ProcessingServerService.groovy
@@ -118,10 +118,22 @@ class ProcessingServerService extends ModelService {
 
             //get the path and name for the SSH Keysfiles
             String keyPath=Holders.getGrailsApplication().config.grails.serverSshKeysPath
-            String prefixFile=Holders.getGrailsApplication().config.grails.prefixNameOfSSHFile
-            keyPath+=prefixFile
-            keyPath+="_"
-            keyPath+=(domain as ProcessingServer).id
+            //on recupere le hostname
+            String pathToCreate=(domain as ProcessingServer).host
+            keyPath+="/"
+            keyPath+=pathToCreate
+            try {
+                File f = new File(keyPath)
+                boolean bool = false
+                bool = f.mkdir()
+                log.info("Directory $keyPath created? $bool")
+            } catch(Exception e) {
+                // if any error occurs
+                e.printStackTrace()
+            }
+            keyPath+="/"+pathToCreate
+            def  a = 5
+            log.info("$a   $keyPath")
             //creation of ssh keys for this processingServer
             com.jcraft.jsch.KeyPair kpair=com.jcraft.jsch.KeyPair.genKeyPair(new JSch(),com.jcraft.jsch.KeyPair.RSA)
             kpair.writePrivateKey(keyPath)

--- a/grails-app/services/be/cytomine/processing/ProcessingServerService.groovy
+++ b/grails-app/services/be/cytomine/processing/ProcessingServerService.groovy
@@ -88,18 +88,14 @@ class ProcessingServerService extends ModelService {
     def publicKeyProcessingServer(Long id) throws CytomineException {
         SecUser currentUser = cytomineService.getCurrentUser()
         securityACLService.checkAdmin(currentUser)
-            ProcessingServer processingServer = ProcessingServer.findById(id)
+        ProcessingServer processingServer = ProcessingServer.findById(id)
 
-            String keyPath=Holders.getGrailsApplication().config.grails.serverSshKeysPath
-            keyPath+="/"
-            keyPath+=processingServer.host
-            keyPath+="/"
-            keyPath+=processingServer.host+".pub"
-
-            try {
-                String text = new String(Files.readAllBytes(Paths.get(keyPath)))
-                return text
-            } catch (IOException e) { e.printStackTrace() }
+        String keyPath=Holders.getGrailsApplication().config.grails.serverSshKeysPath
+        keyPath+="/"
+        keyPath+=processingServer.host
+        keyPath+="/"
+        keyPath+=processingServer.host+".pub"
+        return keyPath
 
         }
 

--- a/grails-app/services/be/cytomine/processing/ProcessingServerService.groovy
+++ b/grails-app/services/be/cytomine/processing/ProcessingServerService.groovy
@@ -24,6 +24,8 @@ import be.cytomine.middleware.MessageBrokerServer
 import be.cytomine.security.SecUser
 import be.cytomine.utils.ModelService
 import be.cytomine.utils.Task
+import com.jcraft.jsch.JSch
+import grails.util.Holders
 import groovy.json.JsonBuilder
 import org.springframework.security.acls.domain.BasePermission
 
@@ -113,6 +115,18 @@ class ProcessingServerService extends ModelService {
             jsonBuilder(message)
 
             amqpQueueService.publishMessage(AmqpQueue.findByName("queueCommunication"), jsonBuilder.toString())
+
+            //get the path and name for the SSH Keysfiles
+            String keyPath=Holders.getGrailsApplication().config.grails.serverSshKeysPath
+            String prefixFile=Holders.getGrailsApplication().config.grails.prefixNameOfSSHFile
+            keyPath+=prefixFile
+            keyPath+="_"
+            keyPath+=(domain as ProcessingServer).id
+            //creation of ssh keys for this processingServer
+            com.jcraft.jsch.KeyPair kpair=com.jcraft.jsch.KeyPair.genKeyPair(new JSch(),com.jcraft.jsch.KeyPair.RSA)
+            kpair.writePrivateKey(keyPath)
+            kpair.writePublicKey(keyPath+".pub","comment")
+
         }
     }
 

--- a/grails-app/services/be/cytomine/utils/bootstrap/BootstrapOldVersionService.groovy
+++ b/grails-app/services/be/cytomine/utils/bootstrap/BootstrapOldVersionService.groovy
@@ -88,40 +88,28 @@ class BootstrapOldVersionService {
     void init20190401(){
         log.info "20190401"
 
-        //on retrieve tout les processing server
         Collection<ProcessingServer> processingServerCollection=ProcessingServer.findAll()
         for(int i=0;i<processingServerCollection.size();i++)
         {
             ProcessingServer psTmp=processingServerCollection.get(i)
-            log.info("Processing server ${psTmp.id} name: ${psTmp.name} host: ${psTmp.host} username: ${psTmp.username} ")
-            log.info("=======================================================================")
-            //on va crée en dur les mkdir
-                //get the path and name for the SSH Keysfiles
-                String keyPath= Holders.getGrailsApplication().config.grails.serverSshKeysPath
-                //on recupere le hostname
-            log.info("$keyPath")
-                String pathToCreate=psTmp.host
-                keyPath+="/"
-            log.info("$keyPath")
-                keyPath+=pathToCreate
-            log.info("$keyPath")
+            String keyPath= Holders.getGrailsApplication().config.grails.serverSshKeysPath
 
-                try {
-                    File f = new File(keyPath)
-                    boolean bool = false
-                    bool = f.mkdir()
-                    log.info("Directory $keyPath created? $bool")
-                } catch(Exception e) {
-                    // if any error occurs
-                    e.printStackTrace()
+            String hostName=psTmp.host
+            keyPath+="/"
+            keyPath+=hostName
+            try {
+                File f = new File(keyPath)
+                boolean bool = false
+                bool = f.mkdir()
+                log.info("Directory $keyPath created? $bool")
+                if(bool)
+                {
+                    keyPath+="/"+hostName
+                    com.jcraft.jsch.KeyPair kpair=com.jcraft.jsch.KeyPair.genKeyPair(new JSch(),com.jcraft.jsch.KeyPair.RSA)
+                    kpair.writePrivateKey(keyPath)
+                    kpair.writePublicKey(keyPath+".pub","public key of $hostName")
                 }
-                keyPath+="/"+pathToCreate
-                def  a = 5
-                log.info("$a   $keyPath")
-                //creation of ssh keys for this processingServer
-                com.jcraft.jsch.KeyPair kpair=com.jcraft.jsch.KeyPair.genKeyPair(new JSch(),com.jcraft.jsch.KeyPair.RSA)
-                kpair.writePrivateKey(keyPath)
-                kpair.writePublicKey(keyPath+".pub","comment")
+            } catch(Exception e) {e.printStackTrace()}
         }
     }
 

--- a/grails-app/services/be/cytomine/utils/bootstrap/BootstrapUtilsService.groovy
+++ b/grails-app/services/be/cytomine/utils/bootstrap/BootstrapUtilsService.groovy
@@ -25,6 +25,7 @@ import be.cytomine.image.UploadedFile
 import be.cytomine.image.server.*
 import be.cytomine.middleware.AmqpQueue
 import be.cytomine.middleware.MessageBrokerServer
+import be.cytomine.middleware.comsumerRBMQ
 import be.cytomine.ontology.Property
 import be.cytomine.ontology.Relation
 import be.cytomine.ontology.RelationTerm
@@ -36,6 +37,8 @@ import be.cytomine.security.*
 import be.cytomine.social.PersistentImageConsultation
 import be.cytomine.social.PersistentProjectConnection
 import be.cytomine.utils.Configuration
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Connection
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.util.Environment
 import groovy.json.JsonBuilder
@@ -62,7 +65,7 @@ class BootstrapUtilsService {
     def processingServerService
     def configurationService
 
-    public def createUsers(def usersSamples) {
+     def createUsers(def usersSamples) {
 
         SecRole.findByAuthority("ROLE_USER") ?: new SecRole(authority: "ROLE_USER").save(flush: true)
         SecRole.findByAuthority("ROLE_ADMIN") ?: new SecRole(authority: "ROLE_ADMIN").save(flush: true)
@@ -120,7 +123,7 @@ class BootstrapUtilsService {
         return usersCreated
     }
 
-    public def createRelation() {
+     def createRelation() {
         def relationSamples = [
                 [name: RelationTerm.names.PARENT],
                 [name: RelationTerm.names.SYNONYM]
@@ -161,7 +164,7 @@ class BootstrapUtilsService {
         }
     }
 
-    public def createMimes(def mimeSamples) {
+     def createMimes(def mimeSamples) {
         mimeSamples.each {
             if(!Mime.findByMimeType(it.mimeType)) {
                 Mime mime = new Mime(extension : it.extension, mimeType: it.mimeType)
@@ -361,16 +364,16 @@ class BootstrapUtilsService {
     void convertMimeTypes(){
         SpringSecurityUtils.doWithAuth("admin", {
 
-            Mime oldTif = Mime.findByMimeType("image/tif");
-            Mime oldTiff = Mime.findByMimeType("image/tiff");
-            Mime newTiff = Mime.findByMimeType("image/pyrtiff");
+            Mime oldTif = Mime.findByMimeType("image/tif")
+            Mime oldTiff = Mime.findByMimeType("image/tiff")
+            Mime newTiff = Mime.findByMimeType("image/pyrtiff")
 
-            List<AbstractImage> abstractImages = AbstractImage.findAllByMimeInList([oldTif, oldTiff]);
+            List<AbstractImage> abstractImages = AbstractImage.findAllByMimeInList([oldTif, oldTiff])
             log.info "images to convert : "+abstractImages.size()
 
             abstractImages.each {
-                it.mime = newTiff;
-                it.save();
+                it.mime = newTiff
+                it.save()
             }
         })
     }
@@ -427,6 +430,22 @@ class BootstrapUtilsService {
             amqpQueueService.createAmqpQueueDefault(queueCommunication)
         }
 
+
+
+        if(!AmqpQueue.findByName("queueCommunicationRetrieve")){
+            AmqpQueue queueCommunicationRetrieve = new AmqpQueue(name: "queueCommunicationRetrieve", host: mbs.host, exchange: "exchangeCommunicationRetrieve")
+            queueCommunicationRetrieve.save(failOnError: true, flush: true)
+            amqpQueueService.createAmqpQueueDefault(queueCommunicationRetrieve)
+        }
+        else if(!amqpQueueService.checkRabbitQueueExists("queueCommunicationRetrieve",mbs)) {
+            AmqpQueue queueCommunicationRetrieve = amqpQueueService.read("queueCommunicationRetrieve")
+            amqpQueueService.createAmqpQueueDefault(queueCommunicationRetrieve)
+        }
+        Connection connection= rabbitConnectionService.getRabbitConnection(mbs)
+        Channel channel=connection.createChannel()
+        String queueName="queueCommunicationRetrieve"
+        channel.basicConsume(queueName, true, new comsumerRBMQ(channel))
+
         //Inserting a MessageBrokerServer for testing purpose
         if (Environment.getCurrent() == Environment.TEST) {
             rabbitConnectionService.getRabbitConnection(mbs)
@@ -466,7 +485,7 @@ class BootstrapUtilsService {
     def imageConsultationService
     void fillProjectConnections() {
         SpringSecurityUtils.doWithAuth("superadmin", {
-            Date before = new Date();
+            Date before = new Date()
 
             def connections = PersistentProjectConnection.findAllByTimeIsNullOrCountCreatedAnnotationsIsNullOrCountViewedImagesIsNull(sort: 'created', order: 'desc', max: Integer.MAX_VALUE)
             log.info "project connections to update " + connections.size()
@@ -474,7 +493,7 @@ class BootstrapUtilsService {
             def sql = new Sql(dataSource)
 
             for (PersistentProjectConnection projectConnection : connections) {
-                Date after = projectConnection.created;
+                Date after = projectConnection.created
 
                 // collect {it.created.getTime} is really slow. I just want the getTime of PersistentConnection
                 def db = mongo.getDB(noSQLCollectionService.getDatabaseName())
@@ -482,7 +501,7 @@ class BootstrapUtilsService {
                         [$match: [project: projectConnection.project, user: projectConnection.user, $and : [[created: [$gte: after]],[created: [$lte: before]]]]],
                         [$sort: [created: 1]],
                         [$project: [dateInMillis: [$subtract: ['$created', new Date(0L)]]]]
-                );
+                )
 
                 def continuousConnections = lastConnection.results().collect { it.dateInMillis }
 
@@ -495,7 +514,7 @@ class BootstrapUtilsService {
                 }
 
                 projectConnection.time = continuousConnectionIntervals.split{it < 30000}[0].sum()
-                if(projectConnection.time == null) projectConnection.time=0;
+                if(projectConnection.time == null) projectConnection.time=0
 
                 // count viewed images
                 projectConnection.countViewedImages = imageConsultationService.getImagesOfUsersByProjectBetween(projectConnection.user, projectConnection.project,after, before).size()
@@ -508,18 +527,18 @@ class BootstrapUtilsService {
                 String request = "SELECT COUNT(*) FROM user_annotation a WHERE a.project_id = ${projectConnection.project} AND a.user_id = ${projectConnection.user} AND a.created < '${before}' AND a.created > '${after}'"
 
                 sql.eachRow(request) {
-                    projectConnection.countCreatedAnnotations = it[0];
+                    projectConnection.countCreatedAnnotations = it[0]
                 }
 
                 projectConnection.save(flush : true, failOnError: true)
                 before = projectConnection.created
             }
             sql.close()
-        });
+        })
     }
     void fillImageConsultations() {
         SpringSecurityUtils.doWithAuth("superadmin", {
-            Date before = new Date();
+            Date before = new Date()
 
             def consultations = PersistentImageConsultation.findAllByTimeIsNullOrCountCreatedAnnotationsIsNull(sort: 'created', order: 'desc', max: Integer.MAX_VALUE)
             log.info "image consultations to update " + consultations.size()
@@ -527,7 +546,7 @@ class BootstrapUtilsService {
             def sql = new Sql(dataSource)
 
             for (PersistentImageConsultation consultation : consultations) {
-                Date after = consultation.created;
+                Date after = consultation.created
 
                 // collect {it.created.getTime} is really slow. I just want the getTime of PersistentConnection
                 def db = mongo.getDB(noSQLCollectionService.getDatabaseName())
@@ -535,7 +554,7 @@ class BootstrapUtilsService {
                         [$match: [project: consultation.project, user: consultation.user, image: consultation.image, $and : [[created: [$gte: after]],[created: [$lte: before]]]]],
                         [$sort: [created: 1]],
                         [$project: [dateInMillis: [$subtract: ['$created', new Date(0L)]]]]
-                );
+                )
 
                 def continuousConnections = positions.results().collect { it.dateInMillis }
 
@@ -548,7 +567,7 @@ class BootstrapUtilsService {
                 }
 
                 consultation.time = continuousConnectionIntervals.split{it < 30000}[0].sum()
-                if(consultation.time == null) consultation.time=0;
+                if(consultation.time == null) consultation.time=0
 
                 // count created annotations
                 String request = "SELECT COUNT(*) FROM user_annotation a WHERE " +
@@ -558,17 +577,17 @@ class BootstrapUtilsService {
                         "AND a.created < '${before}' AND a.created > '${after}'"
 
                 sql.eachRow(request) {
-                    consultation.countCreatedAnnotations = it[0];
+                    consultation.countCreatedAnnotations = it[0]
                 }
 
                 consultation.save(flush : true, failOnError: true)
                 before = consultation.created
             }
             sql.close()
-        });
+        })
     }
 
-    public void cleanUpGorm() {
+     void cleanUpGorm() {
         def session = sessionFactory.currentSession
         session.flush()
         session.clear()


### PR DESCRIPTION
On this pull request, there's the new implementation of the ssh keys... ( https://tickets.cytomine.be/issue/BOOT-11)
so, each time we add a new processing server, we'll create a folder(with the name of the PS) with a pair of ssh key( a private and a public).
There's also a new API "function". With the new one, we can download a public key of a given processing server. Example: http://localhost-core/api/processing_server/44607/publickey

On this pull request, there's also the creation of the "communication retrieve queue". It'll be useful for a next pull request... https://tickets.cytomine.be/issue/CYTO-463

NB: don't forget to check the others pull request related to this one... ( so: dockerfile & bootstrap)